### PR TITLE
Fix 0px height issue on first layout

### DIFF
--- a/wcviewpager/src/main/java/nevet/me/wcviewpager/WrapContentViewPager.java
+++ b/wcviewpager/src/main/java/nevet/me/wcviewpager/WrapContentViewPager.java
@@ -97,6 +97,8 @@ public class WrapContentViewPager extends ViewPager {
      */
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+        
         widthMeasuredSpec = widthMeasureSpec;
         int mode = MeasureSpec.getMode(heightMeasureSpec);
 


### PR DESCRIPTION
When the ViewPager is first layed out onMeasure can be called before any children have been added (I suspect this when the viewpager is in a scrollview). This results in the viewpager having no height. onMeasure needs to be called at the start so that it can add the child views (private method populate() is called in the parent onMeasure)

This fixes #2 
